### PR TITLE
Adding a reference environment.yml for quick install

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+name: napari
+channels:
+  - conda-forge
+dependencies:
+  - tiledb-py
+  - openslide-python
+  - pip
+  - napari
+  - pip:
+    - tiledb-bioimg
+    - tiledb-cloud


### PR DESCRIPTION
This PR:

- Adds a `yaml` file with the environment packages that need to be installed for the plugin. The package manager used/tested is `mamba`